### PR TITLE
fixing the faucet for the Pandia testnet

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["--cfg", "tokio_unstable"]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,50 @@
+name: Rust CI
+on: [push, pull_request]
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: Swatinem/rust-cache@v1
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: Swatinem/rust-cache@v1
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: Swatinem/rust-cache@v1
+      - run: rustup component add rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -1,0 +1,35 @@
+name: Check Galileo versus latest penumbra
+on: 
+  schedule:
+    - cron: "15 18 * * *"
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: Swatinem/rust-cache@v1
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - uses: Swatinem/rust-cache@v1
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ serenity = { version = "0.10", default-features = false, features = ["client", "
 sqlx = { version = "0.5", features = [ "runtime-tokio-rustls", "postgres", "offline" ] }
 tracing = "0.1"
 tracing-subscriber = "0.2"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.18", features = ["full"]}
 humantime = "2"
 clap = { version = "3", features = ["derive"] }
 serde_json = "1"
@@ -38,3 +38,18 @@ async-stream = "0.3"
 chrono = "0.4"
 serde = "1"
 csv-stream = "0.1"
+
+# External dependencies
+tendermint-config = "0.24.0-pre.1"
+# These are = dependencies to force the whole workspace's dependency tree to go
+# back onto 0.24.0-pre.1, which, unlike 0.24.0-pre.2, doesn't have
+# ecosystem-incompatible breaking changes to the prost version.
+#
+# Longer-term, we can't rely on the upstream to publish versions, so we should plan
+# to fork the crates and maintain our fork.
+tendermint-proto = "=0.24.0-pre.1"
+tendermint = "=0.24.0-pre.1"
+# We don't need this crate at all, but its upstream published a breaking change as
+# 0.7.1 (also prost-related), and depending on an exact version here will exclude
+# the bad update until it's yanked.
+ics23 = "=0.7.0"

--- a/config
+++ b/config
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["--cfg", "tokio_unstable"]  # Required by penumbra-storage

--- a/config
+++ b/config
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["--cfg", "tokio_unstable"]  # Required by penumbra-storage


### PR DESCRIPTION
this PR:
* closes #4, which were preventing building this repo
* updates the syntax to use the new `TransactionPlan` (the `build_send` method we were using no longer exists so this was necessary)
* after sending a transaction, we now sleep for a block such that we avoid note reuse (temporary until the wallet refactor is complete)
* adds a basic CI integration running on push and PR (same as the other repos)
* adds a daily CI job that will build galileo versus latest Penumbra to alert us if we need to make updates

