### PR TITLE
build: track upstream main branch, not tag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,12 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 # Penumbra dependencies
-penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra", tag = "036-iocaste.1" }
-penumbra-crypto = { git = "https://github.com/penumbra-zone/penumbra", tag = "036-iocaste.1" }
-penumbra-custody = { git = "https://github.com/penumbra-zone/penumbra", tag = "036-iocaste.1" }
-penumbra-wallet = { git = "https://github.com/penumbra-zone/penumbra", tag = "036-iocaste.1" }
-penumbra-view = { git = "https://github.com/penumbra-zone/penumbra", tag = "036-iocaste.1" }
-penumbra-transaction = { git = "https://github.com/penumbra-zone/penumbra", tag = "036-iocaste.1" }
+penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra", branch = "main" }
+penumbra-crypto = { git = "https://github.com/penumbra-zone/penumbra", branch = "main" }
+penumbra-custody = { git = "https://github.com/penumbra-zone/penumbra", branch = "main" }
+penumbra-wallet = { git = "https://github.com/penumbra-zone/penumbra", branch = "main" }
+penumbra-view = { git = "https://github.com/penumbra-zone/penumbra", branch = "main" }
+penumbra-transaction = { git = "https://github.com/penumbra-zone/penumbra", branch = "main" }
 
 # External dependencies
 ark-ff = "0.3"

--- a/src/opt/serve.rs
+++ b/src/opt/serve.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 use directories::ProjectDirs;
 use futures::{stream::FuturesUnordered, StreamExt, TryStreamExt};
 use penumbra_crypto::{Value, Zero};
-use penumbra_custody::SoftHSM;
+use penumbra_custody::SoftKms;
 use penumbra_proto::{
     custody::v1alpha1::{
         custody_protocol_service_client::CustodyProtocolServiceClient,
@@ -97,9 +97,9 @@ impl Serve {
 
         // Build a custody service...
         let wallet = Wallet::load(custody_file)?;
-        let soft_hsm = SoftHSM::new(vec![wallet.spend_key.clone()]);
+        let soft_kms = SoftKms::new(vec![wallet.spend_key.clone()]);
         let custody =
-            CustodyProtocolServiceClient::new(CustodyProtocolServiceServer::new(soft_hsm));
+            CustodyProtocolServiceClient::new(CustodyProtocolServiceServer::new(soft_kms));
 
         let fvk = wallet.spend_key.full_viewing_key().clone();
 


### PR DESCRIPTION
The testnet release process involves updating Galileo's Cargo.toml for the most recent testnet tag. While it's grand to have a 1:1 correspondence between Galileo's deps and the testnet version it handles disbursements for, it's quite tedious to bump the deps every week. Let's try tracking main branch, instead. Ultimately we aim to automate the build and rollout of galileo updates, but for now, a human's attention is still required.

We aren't committing `Cargo.lock` in this repo (should we?), so no diff for that file. Towards #17.