### PR TITLE
fix: source address handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,3 +66,13 @@ tendermint = "=0.24.0-pre.1"
 # 0.7.1 (also prost-related), and depending on an exact version here will exclude
 # the bad update until it's yanked.
 ics23 = "=0.7.0"
+
+# Dev-only: override the git URLs for penumbra deps to reference an adjacent
+# local directory. Helps when testing out API changes for Galileo.
+#[patch.'https://github.com/penumbra-zone/penumbra']
+#penumbra-proto = { path = "../penumbra/proto" }
+#penumbra-crypto = { path = "../penumbra/crypto" }
+#penumbra-custody = { path = "../penumbra/custody" }
+#penumbra-wallet = { path = "../penumbra/wallet" }
+#penumbra-view = { path = "../penumbra/view" }
+#penumbra-transaction = { path = "../penumbra/transaction" }

--- a/src/opt/serve.rs
+++ b/src/opt/serve.rs
@@ -52,8 +52,8 @@ pub struct Serve {
     rpc_port: u16,
     /// The source address index in the wallet to use when dispensing tokens (if unspecified uses
     /// any funds available).
-    #[clap(long = "source")]
-    source_address: Option<u64>,
+    #[clap(long = "source", default_value = "0")]
+    source_address: penumbra_crypto::keys::AddressIndex,
     /// Message/channel IDs of as-yet unhonored fund requests. Will scan
     /// all messages including and since the one specified; think of it
     /// as "--catch-up-after". Can be specified as

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -24,7 +24,7 @@ pub struct WalletWorker<V: ViewClient, C: CustodyClient> {
     requests: Option<mpsc::Receiver<Request>>,
     node: String,
     rpc_port: u16,
-    source: Option<u64>,
+    source: penumbra_crypto::keys::AddressIndex,
 }
 
 /// A request that the wallet dispense the listed tokens to a particular address, using some fee.
@@ -85,7 +85,7 @@ impl<V: ViewClient, C: CustodyClient> WalletWorker<V, C> {
         view: V,
         custody: C,
         fvk: FullViewingKey,
-        source_address: Option<u64>,
+        source_address: penumbra_crypto::keys::AddressIndex,
         node: String,
         rpc_port: u16,
     ) -> (mpsc::Sender<Request>, Self) {


### PR DESCRIPTION
Recent migration to Account Groups requires some changes to Galileo: https://github.com/penumbra-zone/penumbra/pull/1994

Also requires Penumbra changes in https://github.com/penumbra-zone/penumbra/pull/2018