### PR TITLE
build: set penumbra deps as relative path

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,45 +6,67 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: Checkout galileo
+        uses: actions/checkout@v2
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
+          path: galileo
 
-  test:
-    name: Test Suite
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
+      - name: Check out penumbra repo
+        uses: actions/checkout@v2
+        with:
+          repository: penumbra-zone/penumbra
+          path: penumbra
+          lfs: true
+
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/cargo@v1
+
+      - uses: Swatinem/rust-cache@v2
         with:
-          command: test
+          workspaces: |
+            galileo
+            penumbra
+
+      # We cannot use the GH action because it doesn't working directory:
+      # support custom working dirs.
+      # - uses: actions-rs/cargo@v1
+      - name: cargo check
+        run:
+          cargo check
+        working-directory: galileo
 
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout galileo
+        uses: actions/checkout@v2
+        with:
+          path: galileo
+
+      - name: Check out penumbra repo
+        uses: actions/checkout@v2
+        with:
+          repository: penumbra-zone/penumbra
+          path: penumbra
+          lfs: true
+
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: Swatinem/rust-cache@v1
-      - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
+
+      - uses: Swatinem/rust-cache@v2
         with:
-          command: fmt
-          args: --all -- --check
+          workspaces: |
+            galileo
+            penumbra
+
+      - name: cargo fmt
+        run:
+          cargo fmt --all -- --check
+        working-directory: galileo

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -8,28 +8,31 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: Checkout galileo
+        uses: actions/checkout@v2
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
+          path: galileo
 
-  test:
-    name: Test Suite
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
+      - name: Check out penumbra repo
+        uses: actions/checkout@v2
+        with:
+          repository: penumbra-zone/penumbra
+          path: penumbra
+          lfs: true
+
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/cargo@v1
+
+      - uses: Swatinem/rust-cache@v2
         with:
-          command: test
+          workspaces: |
+            galileo
+            penumbra
+
+      - name: cargo fmt
+        run:
+          cargo fmt --all -- --check
+        working-directory: galileo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,13 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 # Penumbra dependencies
-penumbra-proto = { git = "https://github.com/penumbra-zone/penumbra", branch = "main" }
-penumbra-crypto = { git = "https://github.com/penumbra-zone/penumbra", branch = "main" }
-penumbra-custody = { git = "https://github.com/penumbra-zone/penumbra", branch = "main" }
-penumbra-wallet = { git = "https://github.com/penumbra-zone/penumbra", branch = "main" }
-penumbra-view = { git = "https://github.com/penumbra-zone/penumbra", branch = "main" }
-penumbra-transaction = { git = "https://github.com/penumbra-zone/penumbra", branch = "main" }
+# TODO: sort out git-lfs dependency so we can fetch git deps again; GH29.
+penumbra-proto = { path = "../penumbra/proto" }
+penumbra-crypto = { path = "../penumbra/crypto" }
+penumbra-custody = { path = "../penumbra/custody" }
+penumbra-wallet = { path = "../penumbra/wallet" }
+penumbra-view = { path = "../penumbra/view" }
+penumbra-transaction = { path = "../penumbra/transaction" }
 
 # External dependencies
 ark-ff = "0.3"
@@ -66,13 +67,3 @@ tendermint = "=0.24.0-pre.1"
 # 0.7.1 (also prost-related), and depending on an exact version here will exclude
 # the bad update until it's yanked.
 ics23 = "=0.7.0"
-
-# Dev-only: override the git URLs for penumbra deps to reference an adjacent
-# local directory. Helps when testing out API changes for Galileo.
-#[patch.'https://github.com/penumbra-zone/penumbra']
-#penumbra-proto = { path = "../penumbra/proto" }
-#penumbra-crypto = { path = "../penumbra/crypto" }
-#penumbra-custody = { path = "../penumbra/custody" }
-#penumbra-wallet = { path = "../penumbra/wallet" }
-#penumbra-view = { path = "../penumbra/view" }
-#penumbra-transaction = { path = "../penumbra/transaction" }

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ location of the wallet managed by the `pcli` command line Penumbra wallet. To se
 create a wallet with `pcli`, then send some tokens to that wallet on the test network. Then, you can
 run Galileo:
 
+## Obtaining dependencies
+
+You must clone the [penumbra repo](https://github.com/penumbra-zone/penumbra)
+side-by-side with the Galileo repo, so that the dependencies are available
+as a relative path. This is a temporary workaround to support Git LFS
+in the Penumbra dependencies.
+See [GH29](https://github.com/penumbra-zone/galileo/issues/29) for details.
+
 ## Running it
 
 ```bash


### PR DESCRIPTION
We recently started using git-lfs in the penumbra repo, and cargo can't fetch lfs artifacts via a git dependency. For now, we'll clone the penumbra repo side-by-side and build from relative path.

Refs #29.