### PR TITLE
fix: history address serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ indexmap = "1.8"
 async-stream = "0.3"
 chrono = { version = "0.4", features = ["serde"] }
 serde = "1"
-csv-stream = "0.1"
+csv = "1.2"
 
 # External dependencies
 tendermint-config = "0.24.0-pre.1"


### PR DESCRIPTION
Follow up to recent account/proto changes. We haven't been running the history command regularly, so it broke during the great serialization transition. The address was being emitted as a b64 string, but we have a display impl that renders it as bech32 readable. Recasting as a string in order to take advantage of that. I'm sure there's a smarter way to do this, but I couldn't get serde's `serialize_with` to play nicely with the non-associated type within my timebox.

Also moved from `csv_stream` -> `csv` in an effort to use well-tested dependencies and focus on the bug in our code, not some other library's.