### PR TITLE
build: make account group id optional

### DIFF
--- a/src/sender.rs
+++ b/src/sender.rs
@@ -80,7 +80,7 @@ where
                 .custody
                 .authorize(AuthorizeRequest {
                     plan: plan.clone(),
-                    account_group_id: self2.fvk.account_group_id(),
+                    account_group_id: Some(self2.fvk.account_group_id()),
                     pre_authorizations: Vec::new(),
                 })
                 .await?


### PR DESCRIPTION
Corresponds to changes in [0], which shipped as part of v0.51.1 for penumbra.

[0] https://github.com/penumbra-zone/penumbra/pull/2405