### PR TITLE
chore: update penumbra deps layout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,13 @@ license = "MIT OR Apache-2.0"
 # this is way too complicated, the features in the penumbra crates need to be fixed
 [features]
 default = ["parallel"]
-parallel = ["penumbra-wallet/parallel", "penumbra-crypto/parallel"]
+parallel = ["penumbra-wallet/parallel"]
 
 [dependencies]
 # Penumbra dependencies
 penumbra-proto = { path = "../penumbra/crates/proto" }
-penumbra-crypto = { path = "../penumbra/crates/core/crypto" }
+penumbra-asset = { path = "../penumbra/crates/core/asset" }
+penumbra-keys = { path = "../penumbra/crates/core/keys" }
 penumbra-custody = { path = "../penumbra/crates/custody" }
 penumbra-wallet = { path = "../penumbra/crates/wallet" }
 penumbra-view = { path = "../penumbra/crates/view" }
@@ -50,3 +51,4 @@ chrono = { version = "0.4", features = ["serde"] }
 serde = "1"
 csv = "1.2"
 url = "2"
+num-traits = "0.2"

--- a/src/opt/history.rs
+++ b/src/opt/history.rs
@@ -3,7 +3,6 @@ use std::{env, sync::Arc};
 use anyhow::Context;
 use async_stream::stream;
 use clap::Parser;
-use csv;
 use futures::{Stream, StreamExt};
 use serde::Serialize;
 use serenity::{

--- a/src/opt/serve.rs
+++ b/src/opt/serve.rs
@@ -2,7 +2,8 @@ use anyhow::Context;
 use clap::Parser;
 use directories::ProjectDirs;
 use futures::{stream::FuturesUnordered, StreamExt, TryStreamExt};
-use penumbra_crypto::{Value, Zero};
+use num_traits::identities::Zero;
+use penumbra_asset::Value;
 use penumbra_custody::soft_kms::SoftKms;
 use penumbra_proto::{
     custody::v1alpha1::{
@@ -48,7 +49,7 @@ pub struct Serve {
     /// The source address index in the wallet to use when dispensing tokens (if unspecified uses
     /// any funds available).
     #[clap(long = "source", default_value = "0")]
-    source_address: penumbra_crypto::keys::AddressIndex,
+    source_address: penumbra_keys::keys::AddressIndex,
     /// Message/channel IDs of as-yet unhonored fund requests. Will scan
     /// all messages including and since the one specified; think of it
     /// as "--catch-up-after". Can be specified as

--- a/src/responder.rs
+++ b/src/responder.rs
@@ -1,5 +1,6 @@
-use penumbra_crypto::{Address, Value};
+use penumbra_asset::Value;
 use penumbra_custody::CustodyClient;
+use penumbra_keys::Address;
 use penumbra_transaction::Id;
 use penumbra_view::ViewClient;
 use serenity::prelude::TypeMapKey;

--- a/src/responder/request.rs
+++ b/src/responder/request.rs
@@ -1,4 +1,4 @@
-use penumbra_crypto::Address;
+use penumbra_keys::Address;
 use regex::Regex;
 use serenity::model::channel::Message;
 use tokio::sync::oneshot;

--- a/src/responder/response.rs
+++ b/src/responder/response.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write;
 
-use penumbra_crypto::Address;
+use penumbra_keys::Address;
 use penumbra_transaction::Id;
 use serenity::{client::Cache, model::id::GuildId, prelude::Mentionable};
 

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -1,8 +1,10 @@
 use std::{pin::Pin, task::Poll};
 
 use futures::{Future, FutureExt};
-use penumbra_crypto::{memo::MemoPlaintext, Address, FullViewingKey, Value};
+use penumbra_asset::Value;
 use penumbra_custody::{AuthorizeRequest, CustodyClient};
+use penumbra_keys::{Address, FullViewingKey};
+use penumbra_transaction::memo::MemoPlaintext;
 use penumbra_view::ViewClient;
 use penumbra_wallet::plan::Planner;
 use rand::rngs::OsRng;

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use penumbra_crypto::keys::SpendKey;
+use penumbra_keys::keys::SpendKey;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 


### PR DESCRIPTION
We abolished the crypto crate as part of Testnet 56, so we must update our imports accordingly. Matches changes described in https://github.com/penumbra-zone/penumbra/issues/2765