### PR TITLE
fix: support https for grpc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,4 @@ serde = "1"
 csv = "1.2"
 url = "2"
 num-traits = "0.2"
+tonic = { version = "0.8.1", features = ["tls-webpki-roots", "tls"] }


### PR DESCRIPTION
We were missing a tonic dep that adds support for speaking HTTPS over gRPC. No code changes are required: updating the deps and rebuilding is all that's required.

Closes #48.