### PR TITLE
build: support explicit penumbra versions

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -3,13 +3,18 @@ name: Build container image
 on:
   workflow_call:
   workflow_dispatch:
+    inputs:
+      penumbra_version:
+        description: 'Git ref (e.g. branch or tag) of Penumbra repo for building'
+        default: "main"
+        required: true
   push:
     branches:
       - main
     tags:
       - '**'
 jobs:
-  build-and-push-penumbra:
+  galileo:
     runs-on: buildjet-16vcpu-ubuntu-2004
     permissions:
       contents: read
@@ -45,7 +50,11 @@ jobs:
           platforms: linux/amd64
           file: Containerfile
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          # We include a tag with the associated Penumbra, e.g. `penumbra-v0.57.0`.
+          # This is important to maintain compatibility with a long-running testnet.
+          tags: ${{ steps.meta.outputs.tags }},ghcr.io/penumbra-zone/galileo:penumbra-${{ github.event.inputs.penumbra_version || 'main' }}
+          build-args: |
+            PENUMBRA_VERSION=${{ github.event.inputs.penumbra_version || 'main' }}
           # We disable layer caching to ensure that the most recent penumbra repo is used.
           # Otherwise, the static git url for the repo will always result in a cache hit.
           # TODO: update with dynamic build-args using e.g. current date to bust cache.


### PR DESCRIPTION
Permits building a galileo container image using a specific tagged release of Penumbra. Important to ensure that service restarts don't pull a more recent container that's incompatible.

Closes #60