### PR TITLE
Update tx hash path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+# Intellij IDE settings
+.idea

--- a/src/responder/response.rs
+++ b/src/responder/response.rs
@@ -78,7 +78,7 @@ impl Response {
             for (addr, id) in self.succeeded.iter() {
                 write!(
                     response,
-                    "\n`{}`\ntry `pcli v tx {}`\nor visit https://app.testnet.penumbra.zone/tx/?hash={}",
+                    "\n`{}`\ntry `pcli v tx {}`\nor visit https://app.testnet.penumbra.zone/tx?hash={}",
                     addr.display_short_form(),
                     id,
                     id,


### PR DESCRIPTION
With new website, the trailing slash is deleted