### PR TITLE
chore: bump tonic 0.9 -> 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,4 +52,4 @@ serde = "1"
 csv = "1.2"
 url = "2"
 num-traits = "0.2"
-tonic = { version = "0.9", features = ["tls-webpki-roots", "tls"] }
+tonic = { version = "0.10", features = ["tls-webpki-roots", "tls"] }


### PR DESCRIPTION
Matches changes in [0]. Bump was not broken, as was the case with Osiris [1], but bumping the dep anyway for consistency across the codebase.

[0] https://github.com/penumbra-zone/penumbra/pull/3192
[1] https://github.com/penumbra-zone/osiris/pull/25