### PR TITLE
Spawn the responder in Tokio tasks

### DIFF
--- a/src/opt/serve.rs
+++ b/src/opt/serve.rs
@@ -99,7 +99,6 @@ impl Serve {
         });
         std::fs::create_dir_all(&data_dir).context("can create data dir")?;
 
-        let view_file = data_dir.clone().join("pcli-view.sqlite");
         let custody_file = data_dir.clone().join("custody.json");
 
         // Build a custody service...
@@ -112,15 +111,14 @@ impl Serve {
         let fvk = wallet.spend_key.full_viewing_key().clone();
 
         tracing::debug!("Configuring ViewService against node {}", &self.node);
-        let view_filepath = Some(
-            view_file
-                .to_str()
-                .ok_or_else(|| anyhow::anyhow!("Non-UTF8 view path"))?
-                .to_string(),
-        );
-        let view_storage =
-            penumbra_view::Storage::load_or_initialize(view_filepath, &fvk, self.node.clone())
-                .await?;
+        // Instantiate an in-memory view service.
+        // We pass "None" for the storage path to use an in-memory db, as well.
+        let view_storage = penumbra_view::Storage::load_or_initialize(
+            None::<camino::Utf8PathBuf>,
+            &fvk,
+            self.node.clone(),
+        )
+        .await?;
         let view_service = ViewService::new(view_storage, self.node.clone()).await?;
 
         tracing::debug!("Configuring ViewServiceClient");
@@ -221,7 +219,11 @@ impl Serve {
             result = catch_up => result.context("error in catchup service")?,
             _ = cancel_rx => {
                 // Cancellation received
-                Err(anyhow::anyhow!("cancellation received"))
+                // temporarily disabled due to this causing service restarts leading to long sync times
+                // after restart
+                tracing::warn!("cancellation received");
+                Ok(())
+                // Err(anyhow::anyhow!("cancellation received"))
             }
         }
     }

--- a/src/opt/serve.rs
+++ b/src/opt/serve.rs
@@ -18,11 +18,9 @@ use penumbra_proto::{
 };
 use penumbra_view::{ViewClient, ViewService};
 use serenity::prelude::GatewayIntents;
+use std::{env, path::PathBuf, time::Duration};
 use tokio::sync::oneshot;
 use tower::limit::concurrency::ConcurrencyLimit;
-use tower::load::Load;
-// use serenity::utils::token;
-use std::{env, path::PathBuf, time::Duration};
 use tower::{balance as lb, load};
 use url::Url;
 
@@ -220,11 +218,7 @@ impl Serve {
             result = catch_up => result.context("error in catchup service")?,
             _ = cancel_rx => {
                 // Cancellation received
-                // temporarily disabled due to this causing service restarts leading to long sync times
-                // after restart
-                tracing::warn!("cancellation received");
-                Ok(())
-                // Err(anyhow::anyhow!("cancellation received"))
+                Err(anyhow::anyhow!("cancellation received"))
             }
         }
     }

--- a/src/opt/serve.rs
+++ b/src/opt/serve.rs
@@ -20,6 +20,7 @@ use penumbra_view::{ViewClient, ViewService};
 use serenity::prelude::GatewayIntents;
 use tokio::sync::oneshot;
 use tower::limit::concurrency::ConcurrencyLimit;
+use tower::load::Load;
 // use serenity::utils::token;
 use std::{env, path::PathBuf, time::Duration};
 use tower::{balance as lb, load};


### PR DESCRIPTION
Even though the sender service was made concurrent, the responder was still working serially. This spawns a new tokio task for each responder request, which will then use the load balanced sender services.