### PR TITLE
Use persistent view db

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,3 +60,4 @@ csv = "1.2"
 url = "2"
 num-traits = "0.2"
 tonic = { version = "0.10", features = ["tls-webpki-roots", "tls"] }
+toml = "0.7"

--- a/Containerfile
+++ b/Containerfile
@@ -17,7 +17,7 @@ RUN cargo build --release
 
 # Runtime container, copying in built artifacts
 FROM docker.io/debian:bookworm-slim
-RUN apt-get update && apt-get install -y ca-certificates
+RUN apt-get update && apt-get install -y ca-certificates curl jq
 RUN groupadd --gid 1000 penumbra \
         && useradd -m -d /home/penumbra -g 1000 -u 1000 penumbra
 COPY --from=penumbra /bin/pcli /usr/bin/pcli

--- a/src/opt/serve.rs
+++ b/src/opt/serve.rs
@@ -99,11 +99,11 @@ impl Serve {
         std::fs::create_dir_all(&data_dir).context("can create data dir")?;
 
         let view_file = data_dir.clone().join("pcli-view.sqlite");
-        let custody_file = data_dir.clone().join("custody.json");
+        let pcli_config_file = data_dir.clone().join("config.toml");
 
         // Build a custody service...
-        let wallet =
-            Wallet::load(custody_file).context("Failed to load wallet from local custody file")?;
+        let wallet = Wallet::load(pcli_config_file)
+            .context("Failed to load wallet from local custody file")?;
         let soft_kms = SoftKms::new(wallet.spend_key.clone().into());
         let custody =
             CustodyProtocolServiceClient::new(CustodyProtocolServiceServer::new(soft_kms));

--- a/src/responder.rs
+++ b/src/responder.rs
@@ -93,7 +93,7 @@ where
             response,
         }) = actions.recv().await
         {
-            // let cancel_tx = cancel_tx.clone();
+            let cancel_tx = cancel_tx.clone();
             let values = self.values.clone();
             let senders = self.senders.clone();
             tokio::spawn(async move {
@@ -106,7 +106,7 @@ where
 
                 if !reply.failed().is_empty() {
                     tracing::error!("failed to send funds to some addresses");
-                    // cancel_tx.send(()).await.expect("able to send cancellation");
+                    cancel_tx.send(()).await.expect("able to send cancellation");
                 }
             });
         }


### PR DESCRIPTION
Reverts recent changes from #76. Changes:

* switches from in-memory db to on-disk view db
* updates the custody file format, to match https://github.com/penumbra-zone/penumbra/pull/3239

We've seen very slow syncing behavior on Galileo, so service restarts can block the faucet for ~15m. By using an on-disk db, we'll cache chain scans to keep restarts snappy.

Separate logic required to manage state between chain rollovers. We can do that in the deployment logic. 