### PR TITLE
Batch requests to reduce faucet latency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ penumbra-txhash = { path = "../penumbra/crates/core/txhash" }
 # External dependencies
 tower = { version = "0.4", features = ["balance"] }
 tower-service = { version = "0.3.1" }
+tower-batch = "0.1"
 anyhow = "1"
 futures-util = { version = "0.3", default-features = false, features = [
     "alloc",

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -84,7 +84,7 @@ impl Handler {
         }
 
         // If we made it this far, it's OK to send.
-        return true;
+        true
     }
 }
 

--- a/src/sender.rs
+++ b/src/sender.rs
@@ -63,8 +63,8 @@ where
                 batch: Arc::new(Mutex::new(Vec::new())),
                 result: broadcast::channel(1).0,
             }),
-            25,
-            Duration::from_secs(5),
+            25, // maximum batch size (will be broken up into multiple transactions if size is exceeded)
+            Duration::from_secs(10), // maximum wait time for a batch to be filled (will be sent before filling max batch size if time is exceeded)
         )
     }
 }

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -2,7 +2,6 @@ use anyhow::Context;
 use penumbra_keys::keys::SpendKey;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
-use toml;
 
 /// A wallet file storing a single spend authority.
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
This PR replaces the `ConcurrencyLimit` wrapper around the `Sender` (configured with a concurrency limit of 1, to prevent clashing requests) with a `tower_batch::Batch` wrapper (configured with a max batch size of 25 and a max wait time of 10 seconds). This should substantially improve the faucet's performance, because now the concurrency of the faucet is not strictly limited by the fragmentation of its wallet.

I have not tested this because I don't have permissions to access the bot; I recommend someone tries this in dry-run mode to validate that it works.