### PR TITLE
fix: add FeeTier support to galileo tx sending

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["--cfg", "tokio_unstable"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ parallel = ["penumbra-wallet/parallel"]
 # Penumbra dependencies
 penumbra-proto = { path = "../penumbra/crates/proto", features = ["rpc", "box-grpc"] }
 penumbra-asset = { path = "../penumbra/crates/core/asset" }
+penumbra-fee = { path = "../penumbra/crates/core/component/fee" }
 penumbra-keys = { path = "../penumbra/crates/core/keys" }
 penumbra-custody = { path = "../penumbra/crates/custody" }
 penumbra-wallet = { path = "../penumbra/crates/wallet" }

--- a/src/opt/serve.rs
+++ b/src/opt/serve.rs
@@ -27,9 +27,6 @@ use crate::{
 
 #[derive(Debug, Clone, Parser)]
 pub struct Serve {
-    /// The transaction fee for each response (paid in upenumbra).
-    #[structopt(long, default_value = "0")]
-    fee: u64,
     /// Per-user rate limit (e.g. "10m" or "1day").
     #[clap(short, long, default_value = "1day", parse(try_from_str = humantime::parse_duration))]
     rate_limit: Duration,


### PR DESCRIPTION
During Testnet 77 we enabled fees [0] and in the process broke some things like Galileo. Adding FeeTier support is rather straightforward, although this changeset requires a patch to the `penumbra-fee` crate in order to compile [1].

[0] https://github.com/penumbra-zone/penumbra/issues/4306
[1] https://github.com/penumbra-zone/penumbra/pull/4539