### PR TITLE
fix: don't hard-error on unreadable messages

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -261,7 +261,15 @@ impl EventHandler for Handler {
     /// window, then Galileo will respond instructing the user to wait longer.
     async fn message(&self, ctx: Context, message: Message) {
         // Check whether we should proceed.
-        let message_info = MessageInfo::new(&message, &ctx).unwrap();
+        let message_info = match MessageInfo::new(&message, &ctx) {
+            Ok(m) => m,
+            Err(e) => {
+                // We can't return an error, but we also can't proceed, so log the error
+                // and bare-return to bail out.
+                tracing::error!(%e, "failed to get message info for message");
+                return;
+            }
+        };
         if !self.should_send(&ctx, &message_info).await {
             return;
         }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -265,7 +265,7 @@ impl EventHandler for Handler {
             Ok(m) => m,
             Err(e) => {
                 // We can't return an error, but we also can't proceed, so log the error
-                // and bare-return to bail out.
+                // and early-return to bail out.
                 tracing::error!(%e, "failed to get message info for message");
                 return;
             }

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -1,8 +1,12 @@
+use std::io::IsTerminal as _;
 use tracing_subscriber::{prelude::*, EnvFilter};
 
 /// Initializes a tracing subscriber.
 pub(crate) fn init_subscriber() -> anyhow::Result<()> {
-    let fmt_layer = tracing_subscriber::fmt::layer().with_target(true);
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .with_target(true)
+        .with_ansi(std::io::stderr().is_terminal())
+        .with_writer(std::io::stderr);
     let filter_layer = EnvFilter::try_from_default_env()
         .or_else(|_| EnvFilter::try_new("info"))?
         // Force disabling of r1cs log messages, otherwise the `ark-groth16` crate


### PR DESCRIPTION
For reasons I don't understand, Galileo can fail to create a MessageInfo object from a Message. If that conversion fails, we can't proceed. The  unwrap was causing a fatal error; instead, let's just log it and keep going. Closes #101.

While I was in there, also patched up the logging, to make the logs easier to read when searching. Therefore closes #87.