### PR TITLE
manifest: 🔨 fix build against v0.78.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ penumbra-wallet                        = { path = "../penumbra/crates/wallet" }
 
 # External dependencies
 anyhow                                 = "1"
-axum-server                            = { version = "0.4.7" }
+axum-server                            = { version = "0.5.1" }
 camino                                 = "1"
 directories                            = "4.0.1"
 regex                                  = "1"


### PR DESCRIPTION
 ### 🚁 overview

fixes #104. see penumbra-zone/penumbra#4582.

* penumbra-zone/penumbra#4582
* #104

@conorsch reported this error, when upgrading to a new testnet release:

> While performing the upgrade to Testnet 78
> ([penumbra-zone/penumbra#4582](https://github.com/penumbra-zone/penumbra/issues/4582))
> today, I noticed belated that Galileo isn't building against that
> version of the Penumbra monorepo. See example build failure here:
> https://github.com/penumbra-zone/galileo/actions/runs/9683427186/job/26718838171
>
> ```
> #20 226.5 error[E0277]: the trait bound `rustls_acme::axum::AxumAcceptor: Accept<hyper::server::tcp::addr_stream::AddrStream, _>` is not satisfied
> #20 226.5    --> src/opt/rpc.rs:115:44
> #20 226.5     |
> #20 226.5 115 |                 tokio::task::spawn($server.serve(make_svc))
> #20 226.5     |                                            ^^^^^ the trait `Accept<hyper::server::tcp::addr_stream::AddrStream, _>` is not implemented for `rustls_acme::axum::AxumAcceptor`
> #20 226.5 ...
> #20 226.5 128 |                 spawn_grpc_server!(grpc_server.acceptor(acceptor))
> #20 226.5     |                 -------------------------------------------------- in this macro invocation
> #20 226.5     |
> #20 226.5     = help: the trait `Accept<I, S>` is implemented for `DefaultAcceptor`
> #20 226.5     = note: this error originates in the macro `spawn_grpc_server` (in Nightly builds, run with -Z macro-backtrace for more info)
> #20 226.5
> #20 226.5 error[E0277]: the trait bound `rustls_acme::axum::AxumAcceptor: Accept<hyper::server::tcp::addr_stream::AddrStream, _>` is not satisfied
> #20 226.5    --> src/opt/rpc.rs:115:50
> #20 226.5     |
> #20 226.5 115 |                 tokio::task::spawn($server.serve(make_svc))
> #20 226.5     |                                            ----- ^^^^^^^^ the trait `Accept<hyper::server::tcp::addr_stream::AddrStream, _>` is not implemented for `rustls_acme::axum::AxumAcceptor`
> #20 226.5     |                                            |
> #20 226.5     |                                            required by a bound introduced by this call
> #20 226.5 ...
> #20 226.5 128 |                 spawn_grpc_server!(grpc_server.acceptor(acceptor))
> #20 226.5     |                 -------------------------------------------------- in this macro invocation

this commit fixes that build error.

 ### 😷 diagnosis

running this command in the monorepo...

```sh
; git diff v0.77.4...v0.78.0 Cargo.lock
```

we can see some relevant changes to the dependency tree:

```diff
 [[package]]
 name = "axum-server"
-version = "0.4.7"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bace45b270e36e3c27a190c65883de6dfc9f1d18c829907c127464815dc67b24"
+checksum = "447f28c85900215cc1bea282f32d4a2f22d55c5a300afdfbc661c8d6a632e063"
 dependencies = [
  "arc-swap",
  "bytes",
```

```diff
 [[package]]
 name = "penumbra-auto-https"
-version = "0.77.0"
+version = "0.78.0"
 dependencies = [
  "anyhow",
  "axum-server",
  "futures",
- "rustls 0.20.9",
+ "rustls",
  "rustls-acme",
  "tracing",
 ]
```

the `axum-server` dependency has been upgraded, which in turn affects the version of `axum-server` that the value provided by `penumbra_auto_https::axum_acceptor()` may be used with.

we call that function in `opt/rpc.rs` and provide it to `axum-server`, so Galileo should use the same version as the monorepo.